### PR TITLE
remove bad link

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@ Boo is a language for .Net which appeals to a variety of users due to its clean 
 	
 <h2>Getting started:</h2>
 	The quickest way is to grab a copy of <a href="http://www.icsharpcode.net/opensource/sd/">Sharpdevelop IDE</a> (versions 3 or 4) which has Boo included, 
-    and can convert C# or VB.Net to Boo (or use the <a href="http://codeconverter.sharpdevelop.net/SnippetConverter.aspx"> online version</a>).<br/><br/>
+    and can convert C# or VB.Net to Boo.<br/><br/>
 	Then check out the <a href="https://github.com/boo-lang/boo/wiki/Boo-Primer">Boo primer</a> or other <a href="https://github.com/boo-lang/boo/wiki/Tutorials">Tutorials</a>.
 	
 <h2>What's new:</h2>


### PR DESCRIPTION
The online version of Sharpdevelop IDE no long exists.  Sharpdevelop IDE hasn't been updated in over 5 years. Maybe it should be removed from the page.